### PR TITLE
enable HFXCLK, if necessary; remember previous setting and restore after use; remove 3 magic numbers

### DIFF
--- a/src/clock.rs
+++ b/src/clock.rs
@@ -43,10 +43,10 @@ impl PLLConfig {
         }
 
         let divq: u8 = match output {
-            f if f > 2400_000_000 => {
+            f if f > 2_400_000_000 => {
                 return Err("Requested PLL output frequency is too high");
             }
-            f if f >= 1200_000_000 => 1,
+            f if f >= 1_200_000_000 => 1,
             f if f >= 600_000_000 => 2,
             f if f >= 300_000_000 => 3,
             f if f >= 150_000_000 => 4,
@@ -61,7 +61,7 @@ impl PLLConfig {
         let divr = (0..3)
             .min_by_key(|divr| {
                 let pllin = input / (divr + 1);
-                if pllin < 7_000_000 || pllin >= 200_000_000 {
+                if !(7_000_000..200_000_000).contains(&pllin) {
                     i64::MAX
                 } else {
                     let f1 = vco / (2 * pllin as u64);

--- a/src/clock.rs
+++ b/src/clock.rs
@@ -189,7 +189,9 @@ impl ClockSetup {
                 while self.prci.core_pllcfg.read().plllock().bit_is_clear() {}
 
                 // Select corepll
-                self.prci.corepllsel.modify(|r, w| w.bits(r.bits() & !DVFSCOREPLL_SOURCE));
+                self.prci
+                    .corepllsel
+                    .modify(|r, w| w.bits(r.bits() & !DVFSCOREPLL_SOURCE));
             }
 
             if coreclk != HFXCLK {
@@ -200,7 +202,9 @@ impl ClockSetup {
             }
 
             // Switch peripheral clock to HFXCLK
-            self.prci.hfpclkpllsel.modify(|r, w| w.bits(r.bits() | HFPCLKPLL));
+            self.prci
+                .hfpclkpllsel
+                .modify(|r, w| w.bits(r.bits() | HFPCLKPLL));
 
             // Apply PLL configuration
             self.prci.hfpclk_pllcfg.write_with_zero(|w| {
@@ -224,7 +228,9 @@ impl ClockSetup {
 
             if pclk != HFXCLK / 2 {
                 // Select PLL as a peripheral clock source
-                self.prci.hfpclkpllsel.modify(|r, w| w.bits(r.bits() & !HFPCLKPLL));
+                self.prci
+                    .hfpclkpllsel
+                    .modify(|r, w| w.bits(r.bits() & !HFPCLKPLL));
             }
 
             // Set divider to 0 (divide by 2)

--- a/src/stdout.rs
+++ b/src/stdout.rs
@@ -18,8 +18,8 @@ struct SerialWrapper(Tx<UART0>);
 impl fmt::Write for SerialWrapper {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for byte in s.as_bytes() {
-            if *byte == '\n' as u8 {
-                let res = block!(self.0.write('\r' as u8));
+            if *byte == b'\n' {
+                let res = block!(self.0.write(b'\r'));
 
                 if res.is_err() {
                     return Err(::core::fmt::Error);

--- a/src/time.rs
+++ b/src/time.rs
@@ -66,4 +66,3 @@ impl From<MegaHertz> for KiloHertz {
         Self(mhz.0 * 1_000)
     }
 }
-

--- a/src/time.rs
+++ b/src/time.rs
@@ -49,20 +49,21 @@ impl U32Ext for u32 {
     }
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
+impl From<KiloHertz> for Hertz {
+    fn from(khz: KiloHertz) -> Self {
+        Self(khz.0 * 1_000)
     }
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
+impl From<MegaHertz> for Hertz {
+    fn from(mhz: MegaHertz) -> Self {
+        Self(mhz.0 * 1_000_000)
     }
 }
 
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
+impl From<MegaHertz> for KiloHertz {
+    fn from(mhz: MegaHertz) -> Self {
+        Self(mhz.0 * 1_000)
     }
 }
+


### PR DESCRIPTION
* No longer assumes HFXCLK is enabled
* Restores HFXCLK state after use, if we changed it
* Removes 3 magic numbers
